### PR TITLE
Update HaplotypeCaller workflow for RNAseq analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,43 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## 2.3.0 - 2025-03-04
-- [GRD-872](https://jira.oicr.on.ca/browse/GRD-872) - Update to add RNA mode option, setting up DNA and -ERC GCVF by default
+### Removed
+- Revmoved String erc = "GVCF" from the task and now is controlled dinamically via ERC flag
+
+### Changed
+- The output file extension now conditionally depends on the ERC flag
+
+### Added
+- New parameter rnaMode: A boolean flag to handle RNA-seq data (dfault is false)
+- New parameter GVCF: for flexibility to choose output format (defaul is true)
+- [GRD-872](https://jira.oicr.on.ca/browse/GRD-872)
+
 ## 2.2.0 - 2024-06-25
-[GRD-797](https://jira.oicr.on.ca/browse/GRD-797) - add vidarr labels to outputs (changes to medata only)
+### Added
+- add vidarr labels to outputs (changes to medata only)
+[GRD-797](https://jira.oicr.on.ca/browse/GRD-797) 
+
 ## 2.1.1 - 2024-01-23
+### Changed
 - update GATK version from 4.1.7.0 to 4.2.6.1
+
 ## 2.1.0 - 2023-07-07
+### Changed
 - moving assembly-specific settings into wdl
 - [GRD-662](https://jira.oicr.on.ca/browse/GRD-662)
+
 ## 2.0.3 - 2022-08-31
+### Added
 - added `haplotypeCaller_by_tumor_group` workflow for clinical
+
 ## 2.0.2 - 2021-10-06
+### Changed
 - changed the type of filterIntervals to String? to avoid troubles with EXTERNAL type
+
 ## 2.0.1 - 2021-06-01
+### Changed
 - migrate to Vidarr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.3.0 - 2025-03-04
+- [GRD-872](https://jira.oicr.on.ca/browse/GRD-872) - Update to add RNA mode option, setting up DNA and -ERC GCVF by default
 ## 2.2.0 - 2024-06-25
 [GRD-797](https://jira.oicr.on.ca/browse/GRD-797) - add vidarr labels to outputs (changes to medata only)
 ## 2.1.1 - 2024-01-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.3.0 - 2025-03-04
 ### Removed
-- Revmoved String erc = "GVCF" from the task and now is controlled dinamically via ERC flag
+- Removed String erc = "GVCF" from the task and now is controlled dinamically via ERC flag
 
 ### Changed
 - The output file extension now conditionally depends on the ERC flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,38 +6,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.3.0 - 2025-03-04
 ### Removed
-- Removed String erc = "GVCF" from the task and now is controlled dinamically via ERC flag
+- Removed String erc = "GVCF" from the task, and now is controlled dynamically via ERC flag.
 
 ### Changed
-- The output file extension now conditionally depends on the ERC flag
+- The output file extension now conditionally depends on the ERC flag.
 
 ### Added
-- New parameter rnaMode: A boolean flag to handle RNA-seq data (dfault is false)
-- New parameter GVCF: for flexibility to choose output format (defaul is true)
+- New parameter rnaMode: A boolean flag to handle RNA-seq data (default is false).
+- New parameter GVCF: for flexibility to choose output format (default is true).
 - [GRD-872](https://jira.oicr.on.ca/browse/GRD-872)
 
 ## 2.2.0 - 2024-06-25
 ### Added
-- add vidarr labels to outputs (changes to medata only)
+- Added vidarr labels to outputs (changes to metadata only).
 [GRD-797](https://jira.oicr.on.ca/browse/GRD-797) 
 
 ## 2.1.1 - 2024-01-23
 ### Changed
-- update GATK version from 4.1.7.0 to 4.2.6.1
+- Update GATK version from 4.1.7.0 to 4.2.6.1
 
 ## 2.1.0 - 2023-07-07
 ### Changed
-- moving assembly-specific settings into wdl
+- Moving assembly-specific settings into WDL.
 - [GRD-662](https://jira.oicr.on.ca/browse/GRD-662)
 
 ## 2.0.3 - 2022-08-31
 ### Added
-- added `haplotypeCaller_by_tumor_group` workflow for clinical
+- Added `haplotypeCaller_by_tumor_group` workflow for clinical.
 
 ## 2.0.2 - 2021-10-06
 ### Changed
-- changed the type of filterIntervals to String? to avoid troubles with EXTERNAL type
+- Changed the type of filterIntervals to String? to avoid troubles with EXTERNAL type.
 
 ## 2.0.1 - 2021-06-01
 ### Changed
-- migrate to Vidarr
+- Migrate to Vidarr.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Output | Type | Description | Labels
      --dont-use-soft-clipped-bases \
      --standard-min-confidence-threshold-for-calling 20 \
      --max-reads-per-alignment-start 0 \
-     --G StandardAnnotation \
+     -G StandardAnnotation \
      -G StandardHCAnnotation \
      --EXTRA_ARGUMENTS \
      -O OUTPUT \

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Workflow to run the GATK Haplotype Caller
 
+## Overview
+
 ## Dependencies
 
 * [GATK4](https://gatk.broadinstitute.org/hc/en-us/articles/360037225632-HaplotypeCaller)
@@ -31,6 +33,8 @@ Parameter|Value|Default|Description
 ---|---|---|---
 `filterIntervals`|String?|None|Path to a BED file that restricts calling to only the regions in the file.
 `outputFileNamePrefix`|String|basename(bam,".bam")|Prefix for output file.
+`rnaMode`|Boolean|false|flag to indicate whether to run RNA sequencing data. Default is false (DNA mode).
+`GVCF`|Boolean|true|flag to indicated whether the output is VCF or GVCF (default).
 
 
 #### Optional task parameters:
@@ -43,7 +47,6 @@ Parameter|Value|Default|Description
 `callHaplotypes.extraArgs`|String?|None|Additional arguments to be passed directly to the command.
 `callHaplotypes.intervalPadding`|Int|100|The number of bases of padding to add to each interval.
 `callHaplotypes.intervalSetRule`|String|"INTERSECTION"|Set merging approach to use for combining interval inputs.
-`callHaplotypes.erc`|String|"GVCF"|Mode for emitting reference confidence scores.
 `callHaplotypes.jobMemory`|Int|24|Memory allocated to job (in GB).
 `callHaplotypes.overhead`|Int|6|Java overhead memory (in GB). jobMemory - overhead == java Xmx/heap memory.
 `callHaplotypes.cores`|Int|1|The number of cores to allocate to the job.
@@ -63,44 +66,64 @@ Output | Type | Description | Labels
 
 
 ## Commands
-This section lists commands run by haplotypeCaller workflow
+ This section lists commands run by haplotypeCaller workflow
  
-* Running haplotypeCaller
+ * Running haplotypeCaller
  
-Workflow to run the GATK Haplotype Caller
+ Workflow to run the GATK Haplotype Caller
  
-### Parsing intervals
+ ### Parsing intervals
  
-```
+ ```
      echo INTERVALS_TO_PARALLELIZE_BY | tr 'LINE_SEPARATOR' '\n'
-```
+ ```
  
-### Running haplotypeCaller
+ ### Running haplotypeCaller DNA mode
  
-```
+ ```
      set -euo pipefail
  
-     gatk --java-options -Xmx[JOB_MEMORY - OVERHEAD]G 
-        HaplotypeCaller 
-     -R REFERENCE_FASTA
-     -I INPUT_BAM
-     -L INTERVAL_FILE
-     -L FILTER_INTERVALS -isr INTERVAL_SetRule -ip INTERVAL_Padding # Optional
-     -D DBSNP_VCF
-     -ERC ERC EXTRA_ARGUMENTS
-     -O OUTPUT
-```
+     gatk --java-options -Xmx[JOB_MEMORY - OVERHEAD]G HaplotypeCaller \
+     -R REFERENCE_FASTA \
+     -I INPUT_BAM \
+     -L INTERVAL_FILE \
+     -L FILTER_INTERVALS -isr INTERVAL_SetRule -ip INTERVAL_Padding \ # Optional
+     -D DBSNP_VCF \
+     -ERC ERC \
+     --EXTRA_ARGUMENTS \
+     -O OUTPUT \
+ ```
+ ### Running haplotypeCaller RNA mode
  
-### Merging vcf files
+ ```
+     set -euo pipefail
  
-```
+     gatk --java-options -Xmx[JOB_MEMORY - OVERHEAD]G HaplotypeCaller \
+     -R REFERENCE_FASTA \
+     -I INPUT_BAM \
+     -L INTERVAL_FILE \
+     -L FILTER_INTERVALS -isr INTERVAL_SetRule -ip INTERVAL_Padding \ # Optional
+     -D DBSNP_VCF \
+     -ERC ERC \
+     --dont-use-soft-clipped-bases \
+     --standard-min-confidence-threshold-for-calling 20 \
+     --max-reads-per-alignment-start 0 \
+     --G StandardAnnotation \
+     -G StandardHCAnnotation \
+     --EXTRA_ARGUMENTS \
+     -O OUTPUT \
+ ```
+ 
+ ### Merging vcf files
+ 
+ ```
      set -euo pipefail
  
      gatk --java-options "-Xmx[JOB_MEMORY - OVERHEAD]G" MergeVcfs
      -I VCF_FILES
      -O OUTPUT
-```
-## Support
+ ```
+ ## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .
 

--- a/commands.txt
+++ b/commands.txt
@@ -41,7 +41,7 @@ Workflow to run the GATK Haplotype Caller
     --dont-use-soft-clipped-bases \
     --standard-min-confidence-threshold-for-calling 20 \
     --max-reads-per-alignment-start 0 \
-    --G StandardAnnotation \
+    -G StandardAnnotation \
     -G StandardHCAnnotation \
     --EXTRA_ARGUMENTS \
     -O OUTPUT \

--- a/commands.txt
+++ b/commands.txt
@@ -11,20 +11,40 @@ Workflow to run the GATK Haplotype Caller
     echo INTERVALS_TO_PARALLELIZE_BY | tr 'LINE_SEPARATOR' '\n'
 ```
 
-### Running haplotypeCaller
+### Running haplotypeCaller DNA mode
 
 ```
     set -euo pipefail
 
-    gatk --java-options -Xmx[JOB_MEMORY - OVERHEAD]G 
-       HaplotypeCaller 
-    -R REFERENCE_FASTA
-    -I INPUT_BAM
-    -L INTERVAL_FILE
-    -L FILTER_INTERVALS -isr INTERVAL_SetRule -ip INTERVAL_Padding # Optional
-    -D DBSNP_VCF
-    -ERC ERC EXTRA_ARGUMENTS
-    -O OUTPUT
+    gatk --java-options -Xmx[JOB_MEMORY - OVERHEAD]G HaplotypeCaller \
+    -R REFERENCE_FASTA \
+    -I INPUT_BAM \
+    -L INTERVAL_FILE \
+    -L FILTER_INTERVALS -isr INTERVAL_SetRule -ip INTERVAL_Padding \ # Optional
+    -D DBSNP_VCF \
+    -ERC ERC \
+    --EXTRA_ARGUMENTS \
+    -O OUTPUT \
+```
+### Running haplotypeCaller RNA mode
+
+```
+    set -euo pipefail
+
+    gatk --java-options -Xmx[JOB_MEMORY - OVERHEAD]G HaplotypeCaller \
+    -R REFERENCE_FASTA \
+    -I INPUT_BAM \
+    -L INTERVAL_FILE \
+    -L FILTER_INTERVALS -isr INTERVAL_SetRule -ip INTERVAL_Padding \ # Optional
+    -D DBSNP_VCF \
+    -ERC ERC \
+    --dont-use-soft-clipped-bases \
+    --standard-min-confidence-threshold-for-calling 20 \
+    --max-reads-per-alignment-start 0 \
+    --G StandardAnnotation \
+    -G StandardHCAnnotation \
+    --EXTRA_ARGUMENTS \
+    -O OUTPUT \
 ```
 
 ### Merging vcf files

--- a/haplotypeCaller.wdl
+++ b/haplotypeCaller.wdl
@@ -164,7 +164,7 @@ String outputName = "~{outputFileNamePrefix}~{interval}~{if GVCF then '.g.vcf.gz
       -D ~{dbsnpFilePath} \
       ~{if rnaMode then "--dont-use-soft-clipped-bases --standard-min-confidence-threshold-for-calling 20 --max-reads-per-alignment-start 0 --G StandardAnnotation -G StandardHCAnnotation" 
       else ""} \
-      ~{if GVCF then "-ECR GVCF" else "-ERC NONE"} \
+      ~{if GVCF then "-ERC GVCF" else "-ERC NONE"} \
       ~{extraArgs} \
       -O "~{outputName}"
   >>>

--- a/haplotypeCaller.wdl
+++ b/haplotypeCaller.wdl
@@ -15,7 +15,7 @@ workflow haplotypeCaller {
     String reference
     String intervalsToParallelizeBy
     Boolean rnaMode = false
-    Boolean GVCF = false
+    Boolean GVCF = true
   }
   parameter_meta {
       bai: "The index for the BAM file to be used."

--- a/haplotypeCaller.wdl
+++ b/haplotypeCaller.wdl
@@ -162,7 +162,7 @@ String outputName = "~{outputFileNamePrefix}~{interval}~{if GVCF then '.g.vcf.gz
       then "-L ~{filterIntervals} -isr ~{intervalSetRule} -ip ~{intervalPadding}" 
       else ""} \
       -D ~{dbsnpFilePath} \
-      ~{if rnaMode then "--dont-use-soft-clipped-bases --standard-min-confidence-threshold-for-calling 20 --max-reads-per-alignment-start 0 --G StandardAnnotation -G StandardHCAnnotation" 
+      ~{if rnaMode then "--dont-use-soft-clipped-bases --standard-min-confidence-threshold-for-calling 20 --max-reads-per-alignment-start 0 -G StandardAnnotation -G StandardHCAnnotation" 
       else ""} \
       ~{if GVCF then "-ERC GVCF" else "-ERC NONE"} \
       ~{extraArgs} \

--- a/haplotypeCaller.wdl
+++ b/haplotypeCaller.wdl
@@ -24,8 +24,8 @@ workflow haplotypeCaller {
       reference: "Assembly id, i.e. hg38"
       outputFileNamePrefix: "Prefix for output file."
       intervalsToParallelizeBy: "Comma separated list of intervals to split by (e.g. chr1,chr2,chr3,chr4)."
-      rnaMode: "flag to indicate whether to run RNA sequencing data. Default is DNA mode."
-      GVCF: "flag to indicated whether the output is VCF (default) or GVCF." 
+      rnaMode: "flag to indicate whether to run RNA sequencing data. Default is false (DNA mode)."
+      GVCF: "flag to indicated whether the output is VCF or GVCF (default)." 
   }
 
   meta {
@@ -197,8 +197,8 @@ String outputName = "~{outputFileNamePrefix}~{interval}~{if GVCF then '.g.vcf.gz
     overhead: "Java overhead memory (in GB). jobMemory - overhead == java Xmx/heap memory."
     cores: "The number of cores to allocate to the job."
     timeout: "Maximum amount of time (in hours) the task can run for."
-    rnaMode: "Flag to indicate whether to run RNA sequencing data. Default is DNA mode."
-    GVCF: "Flag to indicate whether the output is VCF (default) or GVCF."
+    rnaMode: "flag to indicate whether to run RNA sequencing data. Default is false (DNA mode)."
+    GVCF: "flag to indicated whether the output is VCF or GVCF (default)."
   }
   meta {
       output_meta: {

--- a/haplotypeCaller.wdl
+++ b/haplotypeCaller.wdl
@@ -72,7 +72,6 @@ workflow haplotypeCaller {
          modules  = resources[reference].modules,
          refFasta = resources[reference].refFasta,
          dbsnpFilePath = resources[reference].dbsnpFilePath
-         rnaMode = rnaMode
      }
   }
 

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -27,7 +27,6 @@
             },
             "haplotypeCaller.callHaplotypes.cores": null,
             "haplotypeCaller.callHaplotypes.dbsnpFilePath": null,
-            "haplotypeCaller.callHaplotypes.erc": null,
             "haplotypeCaller.callHaplotypes.extraArgs": null,
             "haplotypeCaller.callHaplotypes.intervalPadding": null,
             "haplotypeCaller.callHaplotypes.intervalSetRule": null,
@@ -48,9 +47,11 @@
             "haplotypeCaller.splitStringToArray.cores": null,
             "haplotypeCaller.splitStringToArray.jobMemory": null,
             "haplotypeCaller.splitStringToArray.lineSeparator": null,
-            "haplotypeCaller.splitStringToArray.timeout": null
+            "haplotypeCaller.splitStringToArray.timeout": null,
+            "haplotypeCaller.rnaMode": null,
+	        "haplotypeCaller.GVCF": null
         },
-        "description": "GATKHaplotypeCaller workflow test",
+        "description": "GATKHaplotypeCaller workflow no intervals test",
         "engineArguments": {
           "read_from_cache": false,
           "write_to_cache": false
@@ -111,7 +112,6 @@
             },
             "haplotypeCaller.callHaplotypes.cores": null,
             "haplotypeCaller.callHaplotypes.dbsnpFilePath": null,
-            "haplotypeCaller.callHaplotypes.erc": null,
             "haplotypeCaller.callHaplotypes.extraArgs": null,
             "haplotypeCaller.callHaplotypes.intervalPadding": null,
             "haplotypeCaller.callHaplotypes.intervalSetRule": null,
@@ -132,9 +132,11 @@
             "haplotypeCaller.splitStringToArray.cores": null,
             "haplotypeCaller.splitStringToArray.jobMemory": null,
             "haplotypeCaller.splitStringToArray.lineSeparator": null,
-            "haplotypeCaller.splitStringToArray.timeout": null
+            "haplotypeCaller.splitStringToArray.timeout": null,
+            "haplotypeCaller.rnaMode": null,
+	        "haplotypeCaller.GVCF": null
         },
-        "description": "GATKHaplotypeCaller workflow test",
+        "description": "GATKHaplotypeCaller workflow with intervals test",
         "engineArguments": {
           "read_from_cache": false,
           "write_to_cache": false
@@ -163,6 +165,176 @@
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
                 "output_metrics": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/2.2.1/output_metrics/HC_with_intervals.metrics",
+                "type": "script"
+            }
+        ]
+    },
+    {
+        "arguments": {
+            "haplotypeCaller.bai": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/input_data/RNAfile.sorted.filter.deduped.realigned.recal.bai",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "haplotypeCaller.bam": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/input_data/RNAfile.sorted.filter.deduped.realigned.recal.bam",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "haplotypeCaller.callHaplotypes.cores": null,
+            "haplotypeCaller.callHaplotypes.dbsnpFilePath": null,
+            "haplotypeCaller.callHaplotypes.extraArgs": null,
+            "haplotypeCaller.callHaplotypes.intervalPadding": null,
+            "haplotypeCaller.callHaplotypes.intervalSetRule": null,
+            "haplotypeCaller.callHaplotypes.jobMemory": null,
+            "haplotypeCaller.callHaplotypes.modules": null,
+            "haplotypeCaller.callHaplotypes.overhead": null,
+            "haplotypeCaller.callHaplotypes.refFasta": null,
+            "haplotypeCaller.callHaplotypes.timeout": null,
+            "haplotypeCaller.filterIntervals": null,
+            "haplotypeCaller.intervalsToParallelizeBy": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY",
+            "haplotypeCaller.mergeGVCFs.cores": null,
+            "haplotypeCaller.mergeGVCFs.jobMemory": null,
+            "haplotypeCaller.mergeGVCFs.modules": "gatk/4.2.6.1",
+            "haplotypeCaller.mergeGVCFs.overhead": null,
+            "haplotypeCaller.mergeGVCFs.timeout": null,
+            "haplotypeCaller.outputFileNamePrefix": "RNAfile",
+            "haplotypeCaller.reference": "hg38",
+            "haplotypeCaller.splitStringToArray.cores": null,
+            "haplotypeCaller.splitStringToArray.jobMemory": null,
+            "haplotypeCaller.splitStringToArray.lineSeparator": null,
+            "haplotypeCaller.splitStringToArray.timeout": null,
+            "haplotypeCaller.rnaMode": "true",
+	        "haplotypeCaller.GVCF": "false"
+        },
+        "description": "GATKHaplotypeCaller RNA-seq workflow no intervals test",
+        "engineArguments": {
+          "read_from_cache": false,
+          "write_to_cache": false
+        },
+        "id": "HC_no_intervals",
+        "metadata": {
+            "haplotypeCaller.outputVcf": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_haplotypeCaller_HC_RNA_no_intervals_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "haplotypeCaller.outputVcfIndex": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_haplotypeCaller_HC_RNA_no_intervals_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            }
+        },
+        "validators": [
+            {
+                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
+                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
+                "output_metrics": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/2.2.1/output_metrics/HC_RNA_no_intervals.metrics",
+                "type": "script"
+            }
+        ]
+    },
+    {
+        "arguments": {
+            "haplotypeCaller.bai": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/input_data/RNAfile.sorted.filter.deduped.realigned.recal.bai",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "haplotypeCaller.bam": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/input_data/RNAfile.sorted.filter.deduped.realigned.recal.bam",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "haplotypeCaller.callHaplotypes.cores": null,
+            "haplotypeCaller.callHaplotypes.dbsnpFilePath": null,
+            "haplotypeCaller.callHaplotypes.extraArgs": null,
+            "haplotypeCaller.callHaplotypes.intervalPadding": null,
+            "haplotypeCaller.callHaplotypes.intervalSetRule": null,
+            "haplotypeCaller.callHaplotypes.jobMemory": null,
+            "haplotypeCaller.callHaplotypes.modules": null,
+            "haplotypeCaller.callHaplotypes.overhead": null,
+            "haplotypeCaller.callHaplotypes.refFasta": null,
+            "haplotypeCaller.callHaplotypes.timeout": null,
+            "haplotypeCaller.filterIntervals": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/RNAfile.val.bed",
+            "haplotypeCaller.intervalsToParallelizeBy": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr9,chr10,chr11,chr12,chr14,chr16,chr17,chr18,chr19,chrX",
+            "haplotypeCaller.mergeGVCFs.cores": null,
+            "haplotypeCaller.mergeGVCFs.jobMemory": null,
+            "haplotypeCaller.mergeGVCFs.modules": "gatk/4.2.6.1",
+            "haplotypeCaller.mergeGVCFs.overhead": null,
+            "haplotypeCaller.mergeGVCFs.timeout": null,
+            "haplotypeCaller.outputFileNamePrefix": null,
+            "haplotypeCaller.reference": "hg38",
+            "haplotypeCaller.splitStringToArray.cores": null,
+            "haplotypeCaller.splitStringToArray.jobMemory": null,
+            "haplotypeCaller.splitStringToArray.lineSeparator": null,
+            "haplotypeCaller.splitStringToArray.timeout": null,
+            "haplotypeCaller.rnaMode": "true",
+	        "haplotypeCaller.GVCF": "false"
+        },
+        "description": "GATKHaplotypeCaller RNA-seq workflow with intervals test",
+        "engineArguments": {
+          "read_from_cache": false,
+          "write_to_cache": false
+        },
+        "id": "HC_with_intervals",
+        "metadata": {
+            "haplotypeCaller.outputVcf": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_haplotypeCaller_HC_RNA_with_intervals_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "haplotypeCaller.outputVcfIndex": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_haplotypeCaller_HC_RNA_with_intervals_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            }
+        },
+        "validators": [
+            {
+                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
+                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
+                "output_metrics": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/2.2.1/output_metrics/HC_RNA_with_intervals.metrics",
                 "type": "script"
             }
         ]

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -173,7 +173,7 @@
         "arguments": {
             "haplotypeCaller.bai": {
                 "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/input_data/RNAfile.sorted.filter.deduped.realigned.recal.bai",
+                    "configuration": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/input_data/SWID_15613141_OCT_011493_Lv_P_PE_265_WT_191213_M00146_0140_000000000-D7W78_CGCTCATT-CCTATCCT_L001.Aligned.sortedByCoord.out.tiny.sorted.bam.bai",
                     "externalIds": [
                         {
                             "id": "TEST",
@@ -185,7 +185,7 @@
             },
             "haplotypeCaller.bam": {
                 "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/input_data/RNAfile.sorted.filter.deduped.realigned.recal.bam",
+                    "configuration": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/input_data/SWID_15613141_OCT_011493_Lv_P_PE_265_WT_191213_M00146_0140_000000000-D7W78_CGCTCATT-CCTATCCT_L001.Aligned.sortedByCoord.out.tiny.sorted.bam",
                     "externalIds": [
                         {
                             "id": "TEST",
@@ -212,7 +212,7 @@
             "haplotypeCaller.mergeGVCFs.modules": "gatk/4.2.6.1",
             "haplotypeCaller.mergeGVCFs.overhead": null,
             "haplotypeCaller.mergeGVCFs.timeout": null,
-            "haplotypeCaller.outputFileNamePrefix": "RNAfile",
+            "haplotypeCaller.outputFileNamePrefix": "SWID_15613141",
             "haplotypeCaller.reference": "hg38",
             "haplotypeCaller.splitStringToArray.cores": null,
             "haplotypeCaller.splitStringToArray.jobMemory": null,
@@ -226,7 +226,7 @@
           "read_from_cache": false,
           "write_to_cache": false
         },
-        "id": "HC_no_intervals",
+        "id": "HC_RNA_no_intervals",
         "metadata": {
             "haplotypeCaller.outputVcf": {
                 "contents": [
@@ -250,91 +250,6 @@
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
                 "output_metrics": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/2.2.1/output_metrics/HC_RNA_no_intervals.metrics",
-                "type": "script"
-            }
-        ]
-    },
-    {
-        "arguments": {
-            "haplotypeCaller.bai": {
-                "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/input_data/RNAfile.sorted.filter.deduped.realigned.recal.bai",
-                    "externalIds": [
-                        {
-                            "id": "TEST",
-                            "provider": "TEST"
-                        }
-                    ]
-                },
-                "type": "EXTERNAL"
-            },
-            "haplotypeCaller.bam": {
-                "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/input_data/RNAfile.sorted.filter.deduped.realigned.recal.bam",
-                    "externalIds": [
-                        {
-                            "id": "TEST",
-                            "provider": "TEST"
-                        }
-                    ]
-                },
-                "type": "EXTERNAL"
-            },
-            "haplotypeCaller.callHaplotypes.cores": null,
-            "haplotypeCaller.callHaplotypes.dbsnpFilePath": null,
-            "haplotypeCaller.callHaplotypes.extraArgs": null,
-            "haplotypeCaller.callHaplotypes.intervalPadding": null,
-            "haplotypeCaller.callHaplotypes.intervalSetRule": null,
-            "haplotypeCaller.callHaplotypes.jobMemory": null,
-            "haplotypeCaller.callHaplotypes.modules": null,
-            "haplotypeCaller.callHaplotypes.overhead": null,
-            "haplotypeCaller.callHaplotypes.refFasta": null,
-            "haplotypeCaller.callHaplotypes.timeout": null,
-            "haplotypeCaller.filterIntervals": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/workflow/development/RNAfile.val.bed",
-            "haplotypeCaller.intervalsToParallelizeBy": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr9,chr10,chr11,chr12,chr14,chr16,chr17,chr18,chr19,chrX",
-            "haplotypeCaller.mergeGVCFs.cores": null,
-            "haplotypeCaller.mergeGVCFs.jobMemory": null,
-            "haplotypeCaller.mergeGVCFs.modules": "gatk/4.2.6.1",
-            "haplotypeCaller.mergeGVCFs.overhead": null,
-            "haplotypeCaller.mergeGVCFs.timeout": null,
-            "haplotypeCaller.outputFileNamePrefix": null,
-            "haplotypeCaller.reference": "hg38",
-            "haplotypeCaller.splitStringToArray.cores": null,
-            "haplotypeCaller.splitStringToArray.jobMemory": null,
-            "haplotypeCaller.splitStringToArray.lineSeparator": null,
-            "haplotypeCaller.splitStringToArray.timeout": null,
-            "haplotypeCaller.rnaMode": "true",
-	        "haplotypeCaller.GVCF": "false"
-        },
-        "description": "GATKHaplotypeCaller RNA-seq workflow with intervals test",
-        "engineArguments": {
-          "read_from_cache": false,
-          "write_to_cache": false
-        },
-        "id": "HC_with_intervals",
-        "metadata": {
-            "haplotypeCaller.outputVcf": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_haplotypeCaller_HC_RNA_with_intervals_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            },
-            "haplotypeCaller.outputVcfIndex": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_haplotypeCaller_HC_RNA_with_intervals_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            }
-        },
-        "validators": [
-            {
-                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
-                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/GATKHaplotypeCaller/2.2.1/output_metrics/HC_RNA_with_intervals.metrics",
                 "type": "script"
             }
         ]

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -218,8 +218,8 @@
             "haplotypeCaller.splitStringToArray.jobMemory": null,
             "haplotypeCaller.splitStringToArray.lineSeparator": null,
             "haplotypeCaller.splitStringToArray.timeout": null,
-            "haplotypeCaller.rnaMode": "true",
-	        "haplotypeCaller.GVCF": "false"
+            "haplotypeCaller.rnaMode": true,
+	        "haplotypeCaller.GVCF": false
         },
         "description": "GATKHaplotypeCaller RNA-seq workflow no intervals test",
         "engineArguments": {


### PR DESCRIPTION
1. Updated the haplotypeCaller WDL file 
    1a. Added options for RNA and ERC settings, and the outputs formats g.vcf.gz and vcf.gz 
     1b. Removed the previous ERC setting.
2. Updated the CHANGELOG.md , commands.txt, README.md 
3. Updated files for regression test.